### PR TITLE
Add support for `symfony/mailer` of version `^8.0` and `symfony/mime` of version `^8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.1 under development
 
 - Chg #69, #72: Change PHP constraint in `composer.json` to `8.1 - 8.5` (@vjik)
+- Enh #74: Add support for `symfony/mailer` of version `^8.0` and `symfony/mime` of version `^8.0` (@vjik)
 
 ## 4.0.0 October 18, 2024
 
@@ -17,8 +18,8 @@
 
 ## 3.0.1 May 24, 2024
 
-- Enh #39: Add support for `symfony/mime` of version ^7.0 (@vjik)
-- Enh #41: Add support for `symfony/mailer` of version ^7.0 (@vjik)
+- Enh #39: Add support for `symfony/mime` of version `^7.0` (@vjik)
+- Enh #41: Add support for `symfony/mailer` of version `^7.0` (@vjik)
 
 ## 3.0.0 February 16, 2023
 

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     ],
     "require": {
         "php": "8.1 - 8.5",
-        "symfony/mailer": "^5.3 || ^6.0 || ^7.0",
-        "symfony/mime": "^5.4 || ^6.2 || ^7.0",
+        "symfony/mailer": "^5.3 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/mime": "^5.4 || ^6.2 || ^7.0 || ^8.0",
         "yiisoft/mailer": "^6.0.1"
     },
     "require-dev": {

--- a/tests/TestAsset/DummyTransport.php
+++ b/tests/TestAsset/DummyTransport.php
@@ -32,7 +32,7 @@ final class DummyTransport implements TransportInterface, Stringable
         return $this->sentMessages;
     }
 
-    public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage
+    public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
     {
         if ($message instanceof Email && empty($message->getSubject())) {
             throw new TransportException('Subject is required.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌